### PR TITLE
Add Netlify configuration

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,7 @@
+[build]
+  publish = "build"
+  command = "npm -g install magicbook && magicbook build"
+
+[[redirects]]
+  from = "/"
+  to = "/build1/consolidated.html"


### PR DESCRIPTION
In an effort to make this more accessible, I created a [Netlify](https://www.netlify.com/) config file.

Netlify is a free static site host that will automatically update your site when you push to Github. I forked the repo and created my own netlify site: https://ml-system.netlify.com/. 

If you merge this and create a Netlify account, you can easily create your own site that will update automatically: https://docs.netlify.com/site-deploys/create-deploys/#deploy-with-git. 