### PR TITLE
Fix command to install magicbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ brew install node
 Install `magicbook` with:
 
 ```
-npm install magicbook
+npm install -g magicbook
 ```
 
 Clone this repository:


### PR DESCRIPTION
# Description
When trying to build reading the README, I could't execute magicbook.
I was able to execute magicbook by adding the -g option to the install command.